### PR TITLE
Implemented adaptive greed for write queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/**
 .classpath
 .project
 .settings/**
+bench-*

--- a/src/main/java/org/cqfn/rio/AdaptiveGreed.java
+++ b/src/main/java/org/cqfn/rio/AdaptiveGreed.java
@@ -1,0 +1,100 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 cqfn.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights * to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.cqfn.rio;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.reactivestreams.Subscription;
+
+/**
+ * Adaptive write greed that pays attention to
+ * consumers demands.
+ * @since 0.3
+ */
+public final class AdaptiveGreed implements WriteGreed {
+
+    /**
+     * Amount to request.
+     */
+    private volatile long amount;
+
+    /**
+     * Request shift.
+     * <p>
+     * If shift is greater than zero, this object will request
+     * next chunk before all previous chunks were consumed. E.g.
+     * if it's requesting 100 items on each iteration and shift is equal to 2,
+     * then next request of 100 items will occur on 98 item.
+     * </p>
+     */
+    private volatile long shift;
+
+    /**
+     * Counter.
+     */
+    private final AtomicLong cnt;
+
+    /**
+     * Received counter.
+     */
+    private final AtomicLong rec;
+
+    /**
+     * New adaptie greed with initial values.
+     * @param amount Amount to request
+     * @param shift Request items before shifted amount was processed
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public AdaptiveGreed(final long amount, final long shift) {
+        if (shift >= amount) {
+            throw new IllegalArgumentException("Shift should be less than amount");
+        }
+        this.amount = amount;
+        this.shift = shift;
+        this.cnt = new AtomicLong();
+        this.rec = new AtomicLong();
+    }
+
+    @Override
+    public boolean request(final Subscription sub) {
+        final long pos = this.cnt.getAndIncrement();
+        final boolean result = pos == 0 || pos % (this.amount - this.shift + 1) == 0;
+        if (result) {
+            if (this.cnt.get() - this.rec.get() < this.shift + 1) {
+                this.shift *= 2;
+            }
+            if (this.shift > this.amount / 2) {
+                this.amount *= 2;
+            }
+            sub.request(this.amount);
+        }
+        return result;
+    }
+
+    @Override
+    public void received() {
+        this.rec.incrementAndGet();
+    }
+}

--- a/src/main/java/org/cqfn/rio/IoExecutor.java
+++ b/src/main/java/org/cqfn/rio/IoExecutor.java
@@ -1,0 +1,159 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 cqfn.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights * to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.cqfn.rio;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Standard IO executor.
+ * @since 0.3
+ */
+public final class IoExecutor extends AbstractExecutorService {
+
+    /**
+     * Default shared instance cache.
+     */
+    private static volatile ExecutorService shr;
+
+    /**
+     * Origin service.
+     */
+    private final ExecutorService origin;
+
+    /**
+     * Default constructor.
+     */
+    IoExecutor() {
+        this(new Factory("rio"));
+    }
+
+    /**
+     * New IO executor with thread factory.
+     * @param factory For new threads
+     */
+    IoExecutor(final ThreadFactory factory) {
+        this(
+            Executors.newFixedThreadPool(
+                Runtime.getRuntime().availableProcessors(),
+                factory
+            )
+        );
+    }
+
+    /**
+     * Primary ctor.
+     * @param origin Executor
+     */
+    IoExecutor(final ExecutorService origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public void execute(final Runnable arg) {
+        this.origin.execute(arg);
+    }
+
+    @Override
+    public boolean awaitTermination(final long time, final TimeUnit unit)
+        throws InterruptedException {
+        return this.origin.awaitTermination(time, unit);
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return this.origin.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return this.origin.isTerminated();
+    }
+
+    @Override
+    public void shutdown() {
+        this.origin.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return this.origin.shutdownNow();
+    }
+
+    /**
+     * Shared executor service.
+     * @return Shared instance
+     */
+    @SuppressWarnings({"PMD.ProhibitPublicStaticMethods", "PMD.DoubleCheckedLocking"})
+    public static ExecutorService shared() {
+        if (IoExecutor.shr == null) {
+            synchronized (IoExecutor.class) {
+                if (IoExecutor.shr == null) {
+                    IoExecutor.shr = new IoExecutor();
+                }
+            }
+        }
+        return IoExecutor.shr;
+    }
+
+    /**
+     * Factory for IO threads.
+     * @since 0.3
+     */
+    private static final class Factory implements ThreadFactory {
+
+        /**
+         * Thread prefix.
+         */
+        private final String prefix;
+
+        /**
+         * Thread name counter.
+         */
+        private final AtomicInteger cnt;
+
+        /**
+         * New factory for thread with prefix names.
+         * @param prefix Name prefix
+         */
+        Factory(final String prefix) {
+            this.prefix = prefix;
+            this.cnt = new AtomicInteger();
+        }
+
+        @Override
+        public Thread newThread(final Runnable run) {
+            final Thread thr = new Thread(run);
+            thr.setName(String.format("%s-%d", this.prefix, this.cnt.getAndIncrement()));
+            return thr;
+        }
+    }
+}

--- a/src/main/java/org/cqfn/rio/WriteGreed.java
+++ b/src/main/java/org/cqfn/rio/WriteGreed.java
@@ -54,6 +54,21 @@ public interface WriteGreed {
     boolean request(Subscription sub);
 
     /**
+     * Notify item was received.
+     */
+    default void received() {
+        // do nothing
+    }
+
+    /**
+     * Try to convert into adaptive mode.
+     * @return Adaptive greed if applicable.
+     */
+    default WriteGreed adaptive() {
+        return this;
+    }
+
+    /**
      * Request always constant amount.
      * @since 0.2
      */
@@ -103,6 +118,11 @@ public interface WriteGreed {
                 sub.request(this.amount);
             }
             return result;
+        }
+
+        @Override
+        public WriteGreed adaptive() {
+            return new AdaptiveGreed(this.amount, this.shift);
         }
     }
 }

--- a/src/main/java/org/cqfn/rio/channel/ReadableChannel.java
+++ b/src/main/java/org/cqfn/rio/channel/ReadableChannel.java
@@ -28,8 +28,8 @@ package org.cqfn.rio.channel;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
 import org.cqfn.rio.Buffers;
+import org.cqfn.rio.IoExecutor;
 import org.reactivestreams.Publisher;
 
 /**
@@ -39,11 +39,6 @@ import org.reactivestreams.Publisher;
 public final class ReadableChannel {
 
     /**
-     * Default IO executor service.
-     */
-    static final ExecutorService DEFAULT_IO = new ForkJoinPool();
-
-    /**
      * Source channel.
      */
     private final ChannelSource<? extends ReadableByteChannel> chan;
@@ -51,14 +46,14 @@ public final class ReadableChannel {
     /**
      * IO exec.
      */
-    private final ExecutorService ioexec;
+    private final ExecutorService exec;
 
     /**
      * Extends channel with publisher providers methods.
      * @param chan Source channel
      */
     public ReadableChannel(final ChannelSource<? extends ReadableByteChannel> chan) {
-        this(chan, ReadableChannel.DEFAULT_IO);
+        this(chan, IoExecutor.shared());
     }
 
     /**
@@ -69,17 +64,7 @@ public final class ReadableChannel {
     public ReadableChannel(final ChannelSource<? extends ReadableByteChannel> chan,
         final ExecutorService exec) {
         this.chan = chan;
-        this.ioexec = exec;
-    }
-
-    /**
-     * Read channel reactively as a publisher.
-     * @param buf Buffer allocation strategy
-     * @param exec Executor service for subscriber, use same thread if null
-     * @return Publisher of byte buffers
-     */
-    public Publisher<ByteBuffer> read(final Buffers buf, final ExecutorService exec) {
-        return new ReadableChannelPublisher(this.chan, buf, this.ioexec, exec);
+        this.exec = exec;
     }
 
     /**
@@ -88,7 +73,7 @@ public final class ReadableChannel {
      * @return Publisher of byte buffers
      */
     public Publisher<ByteBuffer> read(final Buffers buf) {
-        return new ReadableChannelPublisher(this.chan, buf, this.ioexec, null);
+        return new ReadableChannelPublisher(this.chan, buf, this.exec);
     }
 }
 

--- a/src/main/java/org/cqfn/rio/channel/ReadableChannelPublisher.java
+++ b/src/main/java/org/cqfn/rio/channel/ReadableChannelPublisher.java
@@ -72,21 +72,14 @@ final class ReadableChannelPublisher implements Publisher<ByteBuffer> {
     private final ExecutorService exec;
 
     /**
-     * Executor service for subscribers.
-     */
-    private final ExecutorService subex;
-
-    /**
      * Ctor.
      * @param src Channel
      * @param buffers Buffers allocation strategy
      * @param exec Executor service for IO operations
-     * @param subex Executor service of subscriber
      */
     ReadableChannelPublisher(final ReadableByteChannel src,
-        final Buffers buffers, final ExecutorService exec,
-        final ExecutorService subex) {
-        this(() -> src, buffers, exec, subex);
+        final Buffers buffers, final ExecutorService exec) {
+        this(() -> src, buffers, exec);
     }
 
     /**
@@ -94,15 +87,12 @@ final class ReadableChannelPublisher implements Publisher<ByteBuffer> {
      * @param src Source of channel
      * @param buffers Buffers allocation strategy
      * @param exec Executor service for IO operations
-     * @param subex Executor service of subscriber
      */
     ReadableChannelPublisher(final ChannelSource<? extends ReadableByteChannel> src,
-        final Buffers buffers, final ExecutorService exec,
-        final ExecutorService subex) {
+        final Buffers buffers, final ExecutorService exec) {
         this.src = src;
         this.buffers = buffers;
         this.exec = exec;
-        this.subex = subex;
     }
 
     @Override
@@ -116,8 +106,7 @@ final class ReadableChannelPublisher implements Publisher<ByteBuffer> {
             subscriber.onError(err);
             return;
         }
-        final ReadSubscriberState<? super ByteBuffer> wrap =
-            new ReadSubscriberState<>(new AsyncSubscriber<>(subscriber, this.subex));
+        final ReadSubscriberState<? super ByteBuffer> wrap = new ReadSubscriberState<>(subscriber);
         wrap.onSubscribe(
             new ReadSubscription(
                 wrap, this.buffers,

--- a/src/main/java/org/cqfn/rio/channel/WritableChannel.java
+++ b/src/main/java/org/cqfn/rio/channel/WritableChannel.java
@@ -29,6 +29,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
+import org.cqfn.rio.IoExecutor;
 import org.cqfn.rio.WriteGreed;
 import org.reactivestreams.Publisher;
 
@@ -53,7 +54,7 @@ public final class WritableChannel {
      * @param src Writable channel source
      */
     public WritableChannel(final ChannelSource<? extends WritableByteChannel> src) {
-        this(src, ReadableChannel.DEFAULT_IO);
+        this(src, IoExecutor.shared());
     }
 
     /**
@@ -65,6 +66,15 @@ public final class WritableChannel {
         final ExecutorService exec) {
         this.src = src;
         this.exec = exec;
+    }
+
+    /**
+     * Write data publisher into the channel.
+     * @param data Publisher
+     * @return Future
+     */
+    public CompletionStage<Void> write(final Publisher<ByteBuffer> data) {
+        return this.write(data, WriteGreed.SYSTEM.adaptive());
     }
 
     /**

--- a/src/main/java/org/cqfn/rio/stream/ReactiveInputStream.java
+++ b/src/main/java/org/cqfn/rio/stream/ReactiveInputStream.java
@@ -28,7 +28,6 @@ package org.cqfn.rio.stream;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
-import java.util.concurrent.ExecutorService;
 import org.cqfn.rio.Buffers;
 import org.cqfn.rio.channel.ReadableChannel;
 import org.reactivestreams.Publisher;
@@ -55,10 +54,9 @@ public final class ReactiveInputStream {
     /**
      * Read input stream as a publisher of byte buffers.
      * @param buf Buffer allocation strategy
-     * @param exec Executor service
      * @return Publisher of bute buffers
      */
-    public Publisher<ByteBuffer> read(final Buffers buf, final ExecutorService exec) {
-        return new ReadableChannel(() -> Channels.newChannel(this.src)).read(buf, exec);
+    public Publisher<ByteBuffer> read(final Buffers buf) {
+        return new ReadableChannel(() -> Channels.newChannel(this.src)).read(buf);
     }
 }

--- a/src/test/java/org/cqfn/rio/channel/ReadableChannelPublisherTest.java
+++ b/src/test/java/org/cqfn/rio/channel/ReadableChannelPublisherTest.java
@@ -30,10 +30,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.spi.AbstractInterruptibleChannel;
 import java.util.Locale;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cqfn.rio.Buffers;
+import org.cqfn.rio.IoExecutor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
@@ -80,8 +79,7 @@ public final class ReadableChannelPublisherTest
         return new ReadableChannelPublisher(
             () -> new SourceChan((int) (capacity * size)),
             () -> ByteBuffer.allocateDirect(capacity),
-            new ForkJoinPool(),
-            Executors.newCachedThreadPool()
+            IoExecutor.shared()
         );
     }
 
@@ -92,8 +90,7 @@ public final class ReadableChannelPublisherTest
                 throw new IOException("test-error");
             },
             Buffers.Standard.K1,
-            Executors.newCachedThreadPool(),
-            null
+            IoExecutor.shared()
         );
     }
 

--- a/src/test/java/org/cqfn/rio/file/FileTest.java
+++ b/src/test/java/org/cqfn/rio/file/FileTest.java
@@ -144,7 +144,7 @@ public final class FileTest {
         final Path dest = tmp.resolve("dst");
         new TestResource("file.bin").copy(src);
         final ExecutorService exec = Executors.newSingleThreadExecutor();
-        new File(dest).write(new File(src).content(Buffers.Standard.K1, exec), exec)
+        new File(dest, exec).write(new File(src, exec).content(Buffers.Standard.K1))
             .toCompletableFuture().get();
         MatcherAssert.assertThat(
             bytesToHex(sha256().digest(Files.readAllBytes(dest))),


### PR DESCRIPTION
Closes #40 - added `AdaptiveGreed` implementation, extended `WriteGreed`
interface with additional methods to handle responses and convert itself
into adaptive version. Also, reverted #34 since it's not a RIO
responsibility to handle subscriber thread.