### PR TITLE
test: fixed test for reactive input stream wrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/**
 .project
 .settings/**
 bench-*
+.vscode/**


### PR DESCRIPTION
Fixed unit test for `ReactiveInputStream`: piped output stream should
be closed to notify connected piped input stream as completed.
Without closing output, input is waiting for next chunk of data,
it returns `-1` for `read` only after closing connected output.

Issue: #31