### PR TITLE
More tests for `ReactiveInputStream`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,11 +81,6 @@ OTHER DEALINGS IN THE SOFTWARE.
       <version>${versions.reactive-streams}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.akarnokd</groupId>
-      <artifactId>rxjava2-jdk8-interop</artifactId>
-      <version>0.3.7</version>
-    </dependency>
-    <dependency>
       <groupId>org.jctools</groupId>
       <artifactId>jctools-core</artifactId>
       <version>3.3.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@ OTHER DEALINGS IN THE SOFTWARE.
       <version>${versions.reactive-streams}</version>
     </dependency>
     <dependency>
+      <groupId>com.github.akarnokd</groupId>
+      <artifactId>rxjava2-jdk8-interop</artifactId>
+      <version>0.3.7</version>
+    </dependency>
+    <dependency>
       <groupId>org.jctools</groupId>
       <artifactId>jctools-core</artifactId>
       <version>3.3.0</version>


### PR DESCRIPTION
Added test for `ReactiveInputStream` to obtain publisher (i need publisher so I can write to storage, not bytes count), when there are a lot of (100 is ok, 200 is not) write operation, everything stacks as usual. 